### PR TITLE
key_rotation: fix disable_shm_cache also for gen_shdict_methods

### DIFF
--- a/lualib/ngx/ssl/session/ticket/key_rotation.lua
+++ b/lualib/ngx/ssl/session/ticket/key_rotation.lua
@@ -262,6 +262,7 @@ function _M.init(opts)
         local meta_shdict = require "resty.shdict.simple"
         meta_shdict_set, meta_shdict_get = meta_shdict.gen_shdict_methods{
             dict_name = shdict_name,
+            disable_shdict = disable_shm_cache,
             debug_logger = dlog,
             warn_logger = warn,
             error_logger = error_log,


### PR DESCRIPTION
Disable_shm_cache needs to be set also on gen_shdict_methods to be effective