### PR TITLE
doc: added doc to trigger external ticket usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ http {
         listen 443 ssl;
         server_name "foo.com";
 
+        # SSL session ticket key sharing
+        # Put a dummy key to trigger external ticket key usage in nginx/OpenSSL
+        # initi_by_lua will repalce this dummy key with existing cached keys
+        # or a random key if cached keys are not available.
+        ssl_session_ticket_key  dummy.key;
+
         ...
     }
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ http {
 
         # SSL session ticket key sharing
         # Put a dummy key to trigger external ticket key usage in nginx/OpenSSL
-        # initi_by_lua will repalce this dummy key with existing cached keys
+        # init_by_lua will repalce this dummy key with existing cached keys
         # or a random key if cached keys are not available.
         ssl_session_ticket_key  dummy.key;
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ http {
 
         # SSL session ticket key sharing
         # Put a dummy key to trigger external ticket key usage in nginx/OpenSSL
-        # init_by_lua will repalce this dummy key with existing cached keys
+        # init_by_lua will replace this dummy key with existing cached keys
         # or a random key if cached keys are not available.
         ssl_session_ticket_key  dummy.key;
 


### PR DESCRIPTION
Added missing documentation from agentz's presentation (https://pt.slideshare.net/zilin11/zi-nginx-conf2015) slide 44.