### PR TITLE
feature: added support for 80 bytes key

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ http {
 
             memc_conn_max_idle_time = 1 * 1000,  -- in ms, for in-pool connections,
                                                   -- optional, default to nil
+            key_length = 48   -- in bytes, optional, default 48, possible 80 if using with
+                              -- nginx > 1.12.0, any other values it will
+                              -- fallback to default length
         }
     }
 
@@ -61,6 +64,7 @@ http {
         # Put a dummy key to trigger external ticket key usage in nginx/OpenSSL
         # init_by_lua* will replace this dummy key with existing cached keys
         # or a random key if cached keys are not available.
+        # If key_length was set to 80 bytes in init_by_lua*, the dummy key needs to be 80 bytes too.
         ssl_session_ticket_key  dummy.key;
 
         ...

--- a/lualib/ngx/ssl/session/ticket.lua
+++ b/lualib/ngx/ssl/session/ticket.lua
@@ -24,9 +24,10 @@ ffi.cdef[[
 int ngx_http_lua_ffi_get_ssl_ctx_count(void *cycle);
 int ngx_http_lua_ffi_get_ssl_ctx_list(void *cycle, void **buf);
 int ngx_http_lua_ffi_update_ticket_encryption_key(void *ctx,
-     const unsigned char *key, unsigned int nkeys, char **err);
+     const unsigned char *key, const unsigned int nkeys,
+     const unsigned int key_length, char **err);
 int ngx_http_lua_ffi_update_last_ticket_decryption_key(void *ctx,
-     const unsigned char *key, char **err);
+     const unsigned char *key, const unsigned int key_length, char **err);
 ]]
 
 
@@ -70,6 +71,7 @@ function _M.update_ticket_encryption_key(key, nkeys)
          local rc = C.ngx_http_lua_ffi_update_ticket_encryption_key(ctx,
                                                                     key,
                                                                     nkeys,
+                                                                    #key,
                                                                     errmsg)
          if rc ~= 0 then -- not NGX_OK
              return nil, ffi_str(errmsg[0])
@@ -96,6 +98,7 @@ function _M.update_last_ticket_decryption_key(key)
     for _, ctx in ipairs(ctxs) do
          local rc = C.ngx_http_lua_ffi_update_last_ticket_decryption_key(ctx,
                                                                          key,
+                                                                         #key,
                                                                          errmsg)
          if rc ~= 0 then -- not NGX_OK
              return nil, ffi_str(errmsg[0])

--- a/lualib/ngx/ssl/session/ticket.lua
+++ b/lualib/ngx/ssl/session/ticket.lua
@@ -62,7 +62,7 @@ function _M.update_ticket_encryption_key(key, nkeys)
     -- OpenSSL session ticket key is 48 bytes.
     -- key structure:
     -- 16 bytes key name, 16 bytes AES key, 16 bytes HMAC key.
-    if not key or #key ~= 48 then
+    if not key or (#key ~= 48 and #key ~= 80) then
         return nil, 'invalid ticket key'
     end
 
@@ -89,7 +89,7 @@ function _M.update_last_ticket_decryption_key(key)
     end
 
     -- OpenSSL session ticket key is 48 bytes.
-    if not key or #key ~= 48 then
+    if not key or (#key ~= 48 and #key ~= 80) then
         return nil, 'invalid ticket key'
     end
 

--- a/lualib/ngx/ssl/session/ticket/key_rotation.lua
+++ b/lualib/ngx/ssl/session/ticket/key_rotation.lua
@@ -99,7 +99,7 @@ local function shdict_get_and_decrypt(ctx, idx)
     -- Ideally we should protect the ticket key with some encryption.
     -- key = decrypt(key, key_encryption_key)
 
-    if #key ~= 48 then
+    if #key ~= 48 and #key ~= 80 then
       return fail("malformed key: #key ", #key)
     end
 
@@ -132,7 +132,7 @@ local function memc_get_and_decrypt(ctx, idx, offset)
     -- Ideally we should protect the ticket key with some encryption.
     -- key = decrypt(key, key_encryption_key)
 
-    if #key ~= 48 then
+    if #key ~= 48 and #key ~= 80 then
       return fail("malformed key: #key ", #key)
     end
 
@@ -256,8 +256,14 @@ function _M.init(opts)
 
     local memc_conn_max_idle_time = opts.memc_conn_max_idle_time
 
+    local key_length = opts.key_length
+
     local frandom = assert(io.open("/dev/urandom", "rb"))
-    fallback_random_key = frandom:read(48)
+    -- if key_length is not set or is different from 48 or 80, use default 48 bytes
+    if not key_length or (key_length ~= 48 and key_length ~= 80) then
+        key_length = 48
+    end
+    fallback_random_key = frandom:read(key_length)
     frandom:close()
 
     nkeys = floor(ticket_ttl / time_slot) + 2

--- a/src/ngx_http_lua_ssl_module.c
+++ b/src/ngx_http_lua_ssl_module.c
@@ -228,9 +228,9 @@ ngx_http_lua_ffi_update_ticket_encryption_key(SSL_CTX *ctx,
         pkey = keys->elts;
         if (ngx_strlen(key) == 48) {
             dd("key size is 48");
-            if (ngx_memcmp(pkey->name, key, 16) == 0 &&
-                ngx_memcmp(pkey->aes_key, key + 16, 16) == 0 &&
-                ngx_memcmp(pkey->hmac_key, key + 32, 16) == 0)
+            if (ngx_memcmp(pkey->name, key, 16) == 0
+                && ngx_memcmp(pkey->aes_key, key + 16, 16) == 0
+                && ngx_memcmp(pkey->hmac_key, key + 32, 16) == 0)
             {
                     dd("duplicate ticket key");
                     return NGX_OK;
@@ -238,9 +238,9 @@ ngx_http_lua_ffi_update_ticket_encryption_key(SSL_CTX *ctx,
 
         } else if (ngx_strlen(key) == 80) {
             dd("key size is 80");
-            if (ngx_memcmp(pkey->name, key, 16) == 0 &&
-                ngx_memcmp(pkey->aes_key, key + 16, 32) == 0 &&
-                ngx_memcmp(pkey->hmac_key, key + 48, 32) == 0 )
+            if (ngx_memcmp(pkey->name, key, 16) == 0
+                && ngx_memcmp(pkey->aes_key, key + 16, 32) == 0
+                && ngx_memcmp(pkey->hmac_key, key + 48, 32) == 0)
             {
                     dd("duplicate ticket key");
                     return NGX_OK;
@@ -268,11 +268,12 @@ ngx_http_lua_ffi_update_ticket_encryption_key(SSL_CTX *ctx,
     }
 
     /* copy the new key */
-    if (ngx_strlen(key) == 48){
+    if (ngx_strlen(key) == 48) {
         ngx_memcpy(pkey->name, key, 16);
         ngx_memcpy(pkey->aes_key, key + 16, 16);
         ngx_memcpy(pkey->hmac_key, key + 32, 16);
-    } else if (ngx_strlen(key) == 80){
+
+    } else if (ngx_strlen(key) == 80) {
         ngx_memcpy(pkey->name, key, 16);
         ngx_memcpy(pkey->aes_key, key + 16, 32);
         ngx_memcpy(pkey->hmac_key, key + 48, 32);
@@ -322,11 +323,12 @@ ngx_http_lua_ffi_update_last_ticket_decryption_key(SSL_CTX *ctx,
     pkey = &pkey[keys->nelts-1];
 
     dd("replace the last key");
-    if (ngx_strlen(key) == 48){
+    if (ngx_strlen(key) == 48) {
         ngx_memcpy(pkey->name, key, 16);
         ngx_memcpy(pkey->aes_key, key + 16, 16);
         ngx_memcpy(pkey->hmac_key, key + 32, 16);
-    } else if (ngx_strlen(key) == 80){
+
+    } else if (ngx_strlen(key) == 80) {
         ngx_memcpy(pkey->name, key, 16);
         ngx_memcpy(pkey->aes_key, key + 16, 32);
         ngx_memcpy(pkey->hmac_key, key + 48, 32);

--- a/src/ngx_http_lua_ssl_module.c
+++ b/src/ngx_http_lua_ssl_module.c
@@ -183,7 +183,8 @@ ngx_http_lua_ffi_get_ssl_ctx_list(ngx_cycle_t *cycle, SSL_CTX **buf)
 
 int
 ngx_http_lua_ffi_update_ticket_encryption_key(SSL_CTX *ctx,
-    const unsigned char  *key, const ngx_uint_t nkeys,  char **err)
+    const unsigned char  *key, const ngx_uint_t nkeys,
+    const unsigned int key_length, char **err)
 {
 #ifdef SSL_CTRL_SET_TLSEXT_TICKET_KEY_CB
 
@@ -226,7 +227,7 @@ ngx_http_lua_ffi_update_ticket_encryption_key(SSL_CTX *ctx,
      * key. */
     if (keys->nelts > 0) {
         pkey = keys->elts;
-        if (ngx_strlen(key) == 48) {
+        if (key_length == 48) {
             dd("key size is 48");
             if (ngx_memcmp(pkey->name, key, 16) == 0
                 && ngx_memcmp(pkey->aes_key, key + 16, 16) == 0
@@ -236,7 +237,7 @@ ngx_http_lua_ffi_update_ticket_encryption_key(SSL_CTX *ctx,
                     return NGX_OK;
             }
 
-        } else if (ngx_strlen(key) == 80) {
+        } else if (key_length == 80) {
             dd("key size is 80");
             if (ngx_memcmp(pkey->name, key, 16) == 0
                 && ngx_memcmp(pkey->aes_key, key + 16, 32) == 0
@@ -268,12 +269,12 @@ ngx_http_lua_ffi_update_ticket_encryption_key(SSL_CTX *ctx,
     }
 
     /* copy the new key */
-    if (ngx_strlen(key) == 48) {
+    if (key_length == 48) {
         ngx_memcpy(pkey->name, key, 16);
         ngx_memcpy(pkey->aes_key, key + 16, 16);
         ngx_memcpy(pkey->hmac_key, key + 32, 16);
 
-    } else if (ngx_strlen(key) == 80) {
+    } else if (key_length == 80) {
         ngx_memcpy(pkey->name, key, 16);
         ngx_memcpy(pkey->aes_key, key + 16, 32);
         ngx_memcpy(pkey->hmac_key, key + 48, 32);
@@ -292,7 +293,7 @@ ngx_http_lua_ffi_update_ticket_encryption_key(SSL_CTX *ctx,
 
 int
 ngx_http_lua_ffi_update_last_ticket_decryption_key(SSL_CTX *ctx,
-    const unsigned char *key, char **err)
+    const unsigned char *key, const unsigned int key_length, char **err)
 {
     ngx_array_t                        *keys;
     ngx_ssl_session_ticket_key_t       *pkey;
@@ -323,12 +324,12 @@ ngx_http_lua_ffi_update_last_ticket_decryption_key(SSL_CTX *ctx,
     pkey = &pkey[keys->nelts-1];
 
     dd("replace the last key");
-    if (ngx_strlen(key) == 48) {
+    if (key_length == 48) {
         ngx_memcpy(pkey->name, key, 16);
         ngx_memcpy(pkey->aes_key, key + 16, 16);
         ngx_memcpy(pkey->hmac_key, key + 32, 16);
 
-    } else if (ngx_strlen(key) == 80) {
+    } else if (key_length == 80) {
         ngx_memcpy(pkey->name, key, 16);
         ngx_memcpy(pkey->aes_key, key + 16, 32);
         ngx_memcpy(pkey->hmac_key, key + 48, 32);

--- a/src/ngx_http_lua_ssl_module.c
+++ b/src/ngx_http_lua_ssl_module.c
@@ -226,12 +226,25 @@ ngx_http_lua_ffi_update_ticket_encryption_key(SSL_CTX *ctx,
      * key. */
     if (keys->nelts > 0) {
         pkey = keys->elts;
-        if (ngx_memcmp(pkey->name, key, 16) == 0 &&
-            ngx_memcmp(pkey->aes_key, key + 16, 16) == 0 &&
-            ngx_memcmp(pkey->hmac_key, key + 32, 16) == 0)
-        {
-            dd("duplicate ticket key");
-            return NGX_OK;
+        if (ngx_strlen(key) == 48) {
+            dd("key size is 48");
+            if (ngx_memcmp(pkey->name, key, 16) == 0 &&
+                ngx_memcmp(pkey->aes_key, key + 16, 16) == 0 &&
+                ngx_memcmp(pkey->hmac_key, key + 32, 16) == 0)
+            {
+                    dd("duplicate ticket key");
+                    return NGX_OK;
+            }
+
+        } else if (ngx_strlen(key) == 80) {
+            dd("key size is 80");
+            if (ngx_memcmp(pkey->name, key, 16) == 0 &&
+                ngx_memcmp(pkey->aes_key, key + 16, 32) == 0 &&
+                ngx_memcmp(pkey->hmac_key, key + 48, 32) == 0 )
+            {
+                    dd("duplicate ticket key");
+                    return NGX_OK;
+            }
         }
     }
 
@@ -255,9 +268,15 @@ ngx_http_lua_ffi_update_ticket_encryption_key(SSL_CTX *ctx,
     }
 
     /* copy the new key */
-    ngx_memcpy(pkey->name, key, 16);
-    ngx_memcpy(pkey->aes_key, key + 16, 16);
-    ngx_memcpy(pkey->hmac_key, key + 32, 16);
+    if (ngx_strlen(key) == 48){
+        ngx_memcpy(pkey->name, key, 16);
+        ngx_memcpy(pkey->aes_key, key + 16, 16);
+        ngx_memcpy(pkey->hmac_key, key + 32, 16);
+    } else if (ngx_strlen(key) == 80){
+        ngx_memcpy(pkey->name, key, 16);
+        ngx_memcpy(pkey->aes_key, key + 16, 32);
+        ngx_memcpy(pkey->hmac_key, key + 48, 32);
+    }
 
     return NGX_OK;
 
@@ -303,9 +322,15 @@ ngx_http_lua_ffi_update_last_ticket_decryption_key(SSL_CTX *ctx,
     pkey = &pkey[keys->nelts-1];
 
     dd("replace the last key");
-    ngx_memcpy(pkey->name, key, 16);
-    ngx_memcpy(pkey->aes_key, key + 16, 16);
-    ngx_memcpy(pkey->hmac_key, key + 32, 16);
+    if (ngx_strlen(key) == 48){
+        ngx_memcpy(pkey->name, key, 16);
+        ngx_memcpy(pkey->aes_key, key + 16, 16);
+        ngx_memcpy(pkey->hmac_key, key + 32, 16);
+    } else if (ngx_strlen(key) == 80){
+        ngx_memcpy(pkey->name, key, 16);
+        ngx_memcpy(pkey->aes_key, key + 16, 32);
+        ngx_memcpy(pkey->hmac_key, key + 48, 32);
+    }
 
     return NGX_OK;
 


### PR DESCRIPTION
Regarding the [issue 6](https://github.com/openresty/lua-ssl-nginx-module/issues/6), I added support for 80 bytes ticket key.

It was tested with nginx 1.12.0, but it should work fine with nginx >= 1.11.8.

It was added a new parameter to init_by_lua*, any value different from 48 or 80 will be ignored and 48 will be used instead. 

The dummy key also needs to be 80 bytes, added documentation for this point.