### PR TITLE
fix: set key size to ngx_ssl_session_ticket_key_t when supported (nginx >= 1.11.8)

### DIFF
--- a/src/ngx_http_lua_ssl_module.c
+++ b/src/ngx_http_lua_ssl_module.c
@@ -258,7 +258,7 @@ ngx_http_lua_ffi_update_ticket_encryption_key(SSL_CTX *ctx,
     ngx_memcpy(pkey->name, key, 16);
     ngx_memcpy(pkey->aes_key, key + 16, 16);
     ngx_memcpy(pkey->hmac_key, key + 32, 16);
-#if (nginx_version > 1011008)
+#if (nginx_version >= 1011008)
     pkey->size = 48;
 #endif
 
@@ -309,7 +309,7 @@ ngx_http_lua_ffi_update_last_ticket_decryption_key(SSL_CTX *ctx,
     ngx_memcpy(pkey->name, key, 16);
     ngx_memcpy(pkey->aes_key, key + 16, 16);
     ngx_memcpy(pkey->hmac_key, key + 32, 16);
-#if (nginx_version > 1011008)
+#if (nginx_version >= 1011008)
     pkey->size = 48;
 #endif
 

--- a/src/ngx_http_lua_ssl_module.c
+++ b/src/ngx_http_lua_ssl_module.c
@@ -258,6 +258,9 @@ ngx_http_lua_ffi_update_ticket_encryption_key(SSL_CTX *ctx,
     ngx_memcpy(pkey->name, key, 16);
     ngx_memcpy(pkey->aes_key, key + 16, 16);
     ngx_memcpy(pkey->hmac_key, key + 32, 16);
+#if (nginx_version > 1011008)
+    pkey->size = 48;
+#endif
 
     return NGX_OK;
 
@@ -306,6 +309,9 @@ ngx_http_lua_ffi_update_last_ticket_decryption_key(SSL_CTX *ctx,
     ngx_memcpy(pkey->name, key, 16);
     ngx_memcpy(pkey->aes_key, key + 16, 16);
     ngx_memcpy(pkey->hmac_key, key + 32, 16);
+#if (nginx_version > 1011008)
+    pkey->size = 48;
+#endif
 
     return NGX_OK;
 


### PR DESCRIPTION
Fixes a problem described on commit message.

> Since version 1.11.8, Nginx has introduced the `size` field in the
> `ngx_ssl_session_ticket_key_t` type, which describes the session
> ticket key length (see commit [1]).
> It can assume either 48 or 80 (representing the key length in bytes).
> Based on this value, Nginx switches to AES-128 to 48-bytes keys
> or AES-256 otherwise (see [2]).
>  
> In practice, this means that when using this module combined with
> Nginx  1.11.8 or later, you always are employing an AES-256 block
> cipher with a 32-bytes key (half randomly generated and another not).
>    
> [1]: https://github.com/nginx/nginx/commit/c2d3d82ccbea18f0504fbaceeee6efb62da8d1d8
> [2]: https://github.com/nginx/nginx/commit/c2d3d82ccbea18f0504fbaceeee6efb62da8d1d8#diff-0584d16332cf0d6dd9adb990a3c76a0cR3023